### PR TITLE
fix: IOutput 인터페이스 분리

### DIFF
--- a/src/common/interfaces/output.interface.ts
+++ b/src/common/interfaces/output.interface.ts
@@ -1,6 +1,9 @@
-export interface IOutput<DataType> {
+export interface IOutput {
   ok: boolean;
-  data?: DataType;
   httpStatus?: number;
   error?: string;
+}
+
+export interface IOutputWithData<DataType> extends IOutput {
+  data?: DataType;
 }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -12,10 +12,7 @@ export class UsersService {
     private readonly users: Repository<User>,
   ) {}
 
-  async createUser({
-    user_id,
-    password,
-  }: CreateUserDto): Promise<IOutput<null>> {
+  async createUser({ user_id, password }: CreateUserDto): Promise<IOutput> {
     try {
       // 1. 아이디 중복 체크
       const existUser = await this.users.findOne({ user_id });


### PR DESCRIPTION
## 종류

- [ ] 버그 수정
- [ ] 신규 기능 추가
- [x] 리팩터링
- [ ] 테스트
- [ ] 기타

## 개요

IOutput 인터페이스 수정

## 상세한 내용

- 기존에는 IOutput 에서 전부 처리했지만, 데이터를 리턴하지 않는데도 제네릭을 선언해야만 했던 기존의 방식을 수정하기 위해, data 항목이 있는 인터페이스 IOutputWithData 를 작성했습니다.
- 이제 data 항목이 없으면 IOutput, 있으면 IOutputWithData 인터페이스를 사용합니다.

resolves: #4
