### PR TITLE
fix/entity 컬럼 수정

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -12,10 +12,10 @@ export class AuthService {
   ) {}
 
   async validateUser(
-    user_id: string,
+    id: string,
     pass: string,
-  ): Promise<IOutputWithData<{ id: number; user_id: string }>> {
-    const user = await this.usersService.findOne(user_id);
+  ): Promise<IOutputWithData<{ idx: number; id: string }>> {
+    const user = await this.usersService.findOne(id);
     if (user) {
       const isCorrectPassword = await bcrypt.compare(pass, user.password);
       if (isCorrectPassword) {
@@ -36,8 +36,7 @@ export class AuthService {
     };
   }
 
-  async login(user: { id: number; user_id: string }) {
-    const payload = { user_id: user.user_id };
-    return { access_token: this.jwtService.sign(payload) };
+  async login(user: { idx: number; id: string }) {
+    return { access_token: this.jwtService.sign(user) };
   }
 }

--- a/src/auth/strategy/jwt.strategy.ts
+++ b/src/auth/strategy/jwt.strategy.ts
@@ -13,7 +13,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     });
   }
 
-  async validate(payload: { id: number; user_id: string }) {
+  async validate(payload: { idx: number; id: string }) {
     return payload;
   }
 }

--- a/src/entities/property.entity.ts
+++ b/src/entities/property.entity.ts
@@ -5,7 +5,7 @@ import { User } from './user.entity';
 @Entity()
 export class Property {
   @PrimaryGeneratedColumn()
-  id: number;
+  idx: number;
 
   @ManyToOne((type) => User, (user) => user.property)
   user: User;

--- a/src/entities/tire.entity.ts
+++ b/src/entities/tire.entity.ts
@@ -5,7 +5,7 @@ import { Property } from './property.entity';
 @Entity()
 export class Tire {
   @PrimaryGeneratedColumn()
-  id: number;
+  idx: number;
 
   @Column()
   @IsNumber()

--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -14,12 +14,12 @@ import { Property } from './property.entity';
 @Entity()
 export class User {
   @PrimaryGeneratedColumn()
-  id: number;
+  idx: number;
 
   @Column()
   @IsString()
   @Length(5, 12)
-  user_id: string;
+  id: string;
 
   @Column()
   @IsString()

--- a/src/users/dto/create-user.dto.ts
+++ b/src/users/dto/create-user.dto.ts
@@ -1,4 +1,4 @@
 import { PickType } from '@nestjs/mapped-types';
 import { User } from '../../entities/user.entity';
 
-export class CreateUserDto extends PickType(User, ['user_id', 'password']) {}
+export class CreateUserDto extends PickType(User, ['id', 'password']) {}

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -12,10 +12,10 @@ export class UsersService {
     private readonly users: Repository<User>,
   ) {}
 
-  async createUser({ user_id, password }: CreateUserDto): Promise<IOutput> {
+  async createUser({ id, password }: CreateUserDto): Promise<IOutput> {
     try {
       // 1. 아이디 중복 체크
-      const existUser = await this.users.findOne({ user_id });
+      const existUser = await this.users.findOne({ id });
       if (existUser) {
         return {
           ok: false,
@@ -24,7 +24,7 @@ export class UsersService {
         };
       }
       // 2. 유저 생성
-      await this.users.save(this.users.create({ user_id, password }));
+      await this.users.save(this.users.create({ id, password }));
       return { ok: true };
     } catch (e) {
       console.log('ERR:', e);
@@ -36,7 +36,7 @@ export class UsersService {
     }
   }
 
-  async findOne(user_id: string): Promise<User | undefined> {
-    return this.users.findOne({ user_id });
+  async findOne(id: string): Promise<User | undefined> {
+    return this.users.findOne({ id });
   }
 }


### PR DESCRIPTION
## 종류

- [ ] 버그 수정
- [ ] 신규 기능 추가
- [ ] 리팩터링
- [ ] 테스트
- [x] 기타

## 개요

엔티티 컬럼의 이름 수정, 로그인과 jwt 토큰 발급 과정을 수정했습니다.

## 상세한 내용

- user 엔티티의 id 컬럼을 idx 로, user_id 를 id 로 수정했습니다.
    - 그 이유는 요구 사항에서는 로그인에 사용할 아이디를 `id`라고 명시하기에, 헷갈림을 방지하기 위해서입니다.
- 그에따라 로그인과 jwt 토큰 발급에서 사용하는 user_id, id 도 같이 수정했습니다.
- tire, property 엔티티의 id 컬럼 역시 idx 로 수정했습니다.

resolves: #2, #6
