### PR TITLE
feat: 타이어를 저장하는 기능 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@nestjs/passport": "^8.0.1",
     "@nestjs/platform-express": "^8.0.0",
     "@nestjs/typeorm": "^8.0.2",
+    "axios": "^0.24.0",
     "bcrypt": "^5.0.1",
     "class-transformer": "^0.4.0",
     "class-validator": "^0.13.1",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,6 +5,7 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { UsersModule } from './users/users.module';
 import { AuthModule } from './auth/auth.module';
+import { PropertiesModule } from './properties/properties.module';
 
 @Module({
   imports: [
@@ -20,6 +21,7 @@ import { AuthModule } from './auth/auth.module';
     }),
     UsersModule,
     AuthModule,
+    PropertiesModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/entities/property.entity.ts
+++ b/src/entities/property.entity.ts
@@ -10,6 +10,6 @@ export class Property {
   @ManyToOne((type) => User, (user) => user.property)
   user: User;
 
-  @ManyToOne((type) => Tire, (tire) => tire.property)
+  @ManyToOne((type) => Tire, (tire) => tire.property, { eager: true })
   tire: Tire;
 }

--- a/src/entities/tire.entity.ts
+++ b/src/entities/tire.entity.ts
@@ -13,12 +13,12 @@ export class Tire {
 
   @Column()
   @IsString()
-  aspect_ratio: string;
+  aspect_ratio: number;
 
   @Column()
   @IsNumber()
   wheel_size: number;
 
-  @OneToMany((type) => Property, (property) => property.tire)
+  @OneToMany((type) => Property, (property) => property.tire, { eager: false })
   property: Property;
 }

--- a/src/properties/dto/create-properties.dto.ts
+++ b/src/properties/dto/create-properties.dto.ts
@@ -1,0 +1,9 @@
+import { IsNumber, IsString } from 'class-validator';
+
+export class CreatePropertiesDto {
+  @IsString()
+  id: string;
+
+  @IsNumber()
+  trimId: number;
+}

--- a/src/properties/properties.controller.spec.ts
+++ b/src/properties/properties.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PropertiesController } from './properties.controller';
+
+describe('PropertiesController', () => {
+  let controller: PropertiesController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [PropertiesController],
+    }).compile();
+
+    controller = module.get<PropertiesController>(PropertiesController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/properties/properties.controller.ts
+++ b/src/properties/properties.controller.ts
@@ -1,0 +1,25 @@
+import { Body, Controller, HttpException, Post } from '@nestjs/common';
+import { CreatePropertiesDto } from './dto/create-properties.dto';
+import { PropertiesService } from './properties.service';
+
+@Controller('properties')
+export class PropertiesController {
+  constructor(private readonly propertiesService: PropertiesService) {}
+
+  @Post()
+  async createProperties(
+    @Body() createPropertiesInput: CreatePropertiesDto[],
+  ): Promise<any> {
+    const inputLength = createPropertiesInput.length;
+    if (inputLength == 0 || inputLength > 5) {
+      throw new HttpException('1개부터 5개끼지 등록하실 수 있습니다.', 400);
+    }
+    const result = await this.propertiesService.createProperties(
+      createPropertiesInput,
+    );
+    if (result.ok) {
+      return '입력해주신 타이어 정보를 저장했습니다. 이전에 같은 아이디와 타이어를 등록한 경우, 중복이라 간주하여 새로 저장하지 않습니다';
+    }
+    throw new HttpException(result.error, result.httpStatus);
+  }
+}

--- a/src/properties/properties.module.ts
+++ b/src/properties/properties.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Property } from '../entities/property.entity';
+import { Tire } from '../entities/tire.entity';
+import { User } from '../entities/user.entity';
+import { PropertiesController } from './properties.controller';
+import { PropertiesService } from './properties.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Property, Tire, User])],
+  controllers: [PropertiesController],
+  providers: [PropertiesService],
+})
+export class PropertiesModule {}

--- a/src/properties/properties.service.spec.ts
+++ b/src/properties/properties.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PropertiesService } from './properties.service';
+
+describe('PropertiesService', () => {
+  let service: PropertiesService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PropertiesService],
+    }).compile();
+
+    service = module.get<PropertiesService>(PropertiesService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/properties/properties.service.ts
+++ b/src/properties/properties.service.ts
@@ -1,0 +1,175 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Connection, Repository } from 'typeorm';
+import { Tire } from '../entities/tire.entity';
+import { Property } from '../entities/property.entity';
+import { User } from '../entities/user.entity';
+import { CreatePropertiesDto } from './dto/create-properties.dto';
+import {
+  IOutput,
+  IOutputWithData,
+} from '../common/interfaces/output.interface';
+import axios from 'axios';
+
+@Injectable()
+export class PropertiesService {
+  constructor(
+    @InjectRepository(Property)
+    private readonly properties: Repository<Property>,
+    @InjectRepository(Tire)
+    private readonly tires: Repository<Tire>,
+    @InjectRepository(User)
+    private readonly users: Repository<User>,
+    private connection: Connection,
+  ) {}
+
+  private async checkAndReturnUser(id: string): Promise<IOutputWithData<User>> {
+    try {
+      const existUser = await this.users.findOne({ id });
+      if (existUser) {
+        return { ok: true, data: existUser };
+      }
+      return {
+        ok: false,
+        httpStatus: 400,
+        error: `${id} 계정이 존재하지 않습니다.`,
+      };
+    } catch (error) {
+      return {
+        ok: false,
+        httpStatus: 500,
+        error: '유저 조회에 에러가 발생했습니다.',
+      };
+    }
+  }
+
+  private extractTireInfoFromString(tireString: string): {
+    width: number;
+    aspect_ratio: number;
+    wheel_size: number;
+  } {
+    // 출처: https://stackoverflow.com/a/42828284
+    const [width, aspectRatio, wheelSize] = tireString.match(/\d+/g);
+    return {
+      width: Number(width),
+      aspect_ratio: Number(aspectRatio),
+      wheel_size: Number(wheelSize),
+    };
+  }
+  private async getTireInfoFromCarApi(
+    trimId: number,
+  ): Promise<
+    IOutputWithData<{ width: number; aspect_ratio: number; wheel_size: number }>
+  > {
+    try {
+      const response = await axios.get(
+        `https://dev.mycar.cardoc.co.kr/v1/trim/${trimId}`,
+      );
+      const tireInfo = this.extractTireInfoFromString(
+        response.data.spec?.driving?.frontTire?.value,
+      );
+      return {
+        ok: true,
+        data: tireInfo,
+      };
+    } catch (err) {
+      return {
+        ok: false,
+        httpStatus: 400,
+        error: `${trimId}은 유효하지 않은 trimId 입니다.`,
+      };
+    }
+  }
+
+  private async checkOrCreateTireEntity(tireInfo: {
+    width: number;
+    aspect_ratio: number;
+    wheel_size: number;
+  }): Promise<Tire> {
+    const existTire = await this.tires.findOne(tireInfo);
+    if (!existTire) {
+      return await this.tires.save(this.tires.create(tireInfo));
+    }
+    return existTire;
+  }
+
+  private async checkOrCreatePropertyEntity({
+    user,
+    tire,
+  }: {
+    user: User;
+    tire: Tire;
+  }): Promise<void> {
+    const existProperty = await this.properties.findOne({ user, tire });
+    if (!existProperty) {
+      await this.properties.save(this.properties.create({ user, tire }));
+    }
+    return;
+  }
+
+  async createProperties(
+    createPropertiesInput: CreatePropertiesDto[],
+  ): Promise<IOutput> {
+    // 결과값을 저장하고 finally 에서 활용합니다.
+    let ok = false;
+    let httpStatus = 500;
+    let error = '';
+    // 이미 조회한 항목은 다시 조회하지 않기 위해 사용합니다.
+    const userEntities = {};
+    const tireEntites = {};
+    const entireTireInfo = {};
+
+    const queryRunner = this.connection.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+
+    try {
+      for (let i = 0; i < createPropertiesInput.length; i++) {
+        const { id, trimId } = createPropertiesInput[i];
+        // * 유효한 유저 아이디인지 확인합니다. 한 번 확인한 아이디는 다시 확인하지 않습니다.
+        if (!userEntities[id]) {
+          const checkUserExistence = await this.checkAndReturnUser(id);
+          if (!checkUserExistence.ok) {
+            httpStatus = checkUserExistence.httpStatus;
+            error = checkUserExistence.error;
+            throw new Error();
+          }
+          Object.assign(userEntities, { [`${id}`]: checkUserExistence.data });
+        }
+
+        // * 카닥 API 에서 차에 대한 정보를 불러옵니다. trimId 결과를 entireTireInfo에 저장하여 같은 trimId 로 API 를 호출하는 것을 방지합니다.
+        if (!entireTireInfo[trimId]) {
+          const carInfo = await this.getTireInfoFromCarApi(trimId);
+          // * 유효한 trimid 로 불러온 것인지 확인합니다.
+          if (!carInfo.ok) {
+            httpStatus = carInfo.httpStatus;
+            error = carInfo.error;
+            throw new Error();
+          }
+          Object.assign(entireTireInfo, { [`${trimId}`]: carInfo.data });
+        }
+
+        // * 타이어에 저장한 것인지 확인하고, 저장하지 않으면 타이어 생성을, 저장했으면 타이어 데이터를 불러옵니다.
+        const tire = await this.checkOrCreateTireEntity(
+          entireTireInfo[`${trimId}`],
+        );
+        Object.assign(tireEntites, { [`${id}`]: tire });
+
+        // * 프로퍼티에 유저 아이디와 타이어 아이디를 저장합니다. 이전에 같은 아이디와 타이어를 등록한 경우, 중복이라 간주하여 새로 저장하지 않습니다.
+        await this.checkOrCreatePropertyEntity({
+          user: userEntities[`${id}`],
+          tire: tireEntites[`${id}`],
+        });
+      }
+
+      ok = true;
+
+      await queryRunner.commitTransaction();
+    } catch (err) {
+      await queryRunner.rollbackTransaction();
+    } finally {
+      await queryRunner.release();
+      return { ok, httpStatus, error };
+    }
+  }
+}


### PR DESCRIPTION
## 종류

- [ ] 버그 수정
- [x] 신규 기능 추가
- [ ] 리팩터링
- [ ] 테스트
- [ ] 기타

## 개요

유저 아이디, trimId 로 타이어를 저장하는 기능을 구현했습니다.

## 상세한 내용

- axios 패키지를 설치했습니다. 카닥 API 를 불러올 때 활용합니다.
- tire 엔티티의 aspect_ratio 를 number 타입으로 수정했습니다.
- tire, property 엔티티에 eager 설정을 추가했습니다. 향후 사용자의 타이어를 불러올 떄 활용합니다.
- transaction 을 이용해 아이디가 틀리거나, 유효한 trimId 를 사용하지 않을 경우 롤백하도록 작성했습니다.
- findOne 으로 찾은 항목, 카닥 API 로 불러온 정보를 특정 객체에 저장하여 같은 기능을 다시 수행하지 않고 객체에서 불러오도록 작성했습니다. (예: 같은 아이디로 여러 개의 타이어를 등록하는 경우, 동일한 trimId 를 여러 번 사용하는 경우)

resolves: #7