### PR TITLE
feat: 타이어 정보 불러오기

### DIFF
--- a/src/properties/dto/get-properties.dto.ts
+++ b/src/properties/dto/get-properties.dto.ts
@@ -1,0 +1,10 @@
+import { IsOptional, IsString } from 'class-validator';
+
+export class GetPropertiesInput {
+  @IsString()
+  page: number;
+
+  @IsString()
+  @IsOptional()
+  limit?: string;
+}

--- a/src/properties/properties.controller.ts
+++ b/src/properties/properties.controller.ts
@@ -1,10 +1,36 @@
-import { Body, Controller, HttpException, Post } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  HttpException,
+  Post,
+  Query,
+  Request,
+  UseGuards,
+} from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { Property } from '../entities/property.entity';
 import { CreatePropertiesDto } from './dto/create-properties.dto';
+import { GetPropertiesInput } from './dto/get-properties.dto';
 import { PropertiesService } from './properties.service';
 
 @Controller('properties')
 export class PropertiesController {
   constructor(private readonly propertiesService: PropertiesService) {}
+
+  @UseGuards(JwtAuthGuard)
+  @Get()
+  async getTireFromUser(
+    @Request() req,
+    @Query() query: GetPropertiesInput,
+  ): Promise<{ count: number; data: Property[] }> {
+    const limit = query?.limit ? Number(query.limit) : 5;
+    return await this.propertiesService.getTireFromUser({
+      page: Number(query.page),
+      limit,
+      user: req.user,
+    });
+  }
 
   @Post()
   async createProperties(

--- a/src/properties/properties.service.ts
+++ b/src/properties/properties.service.ts
@@ -1,3 +1,4 @@
+import axios from 'axios';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Connection, Repository } from 'typeorm';
@@ -9,7 +10,6 @@ import {
   IOutput,
   IOutputWithData,
 } from '../common/interfaces/output.interface';
-import axios from 'axios';
 
 @Injectable()
 export class PropertiesService {
@@ -22,6 +22,26 @@ export class PropertiesService {
     private readonly users: Repository<User>,
     private connection: Connection,
   ) {}
+
+  async getTireFromUser({
+    page,
+    limit,
+    user,
+  }: {
+    page: number;
+    limit: number;
+    user: User;
+  }): Promise<{ count: number; data: Property[] }> {
+    const result = await this.properties.findAndCount({
+      where: { user },
+      take: limit,
+      skip: (page - 1) * limit,
+    });
+    return {
+      count: result[1],
+      data: result[0],
+    };
+  }
 
   private async checkAndReturnUser(id: string): Promise<IOutputWithData<User>> {
     try {


### PR DESCRIPTION
## 종류

- [ ] 버그 수정
- [x] 신규 기능 추가
- [ ] 리팩터링
- [ ] 테스트
- [ ] 기타

## 개요

로그인한 유저가 등록한 타이어 목록을 출력하는 기능을 작성했습니다.

## 상세한 내용

- 로그인한 유저가 등록한 타이어 목록을 불러옵니다.
- JwtAuthGuard 으로 로그인 여부를 확인합니다.
- pagination 을 사용합니다. URI 쿼리에 page, limit 를 입력하여 작동합니다.
- limit 는 선택사항이며, 기본값은 5입니다.
- findAndCount() 를 이용해 전체 개수와 데이터를 함께 출력합니다.

resolves: #8