### PR TITLE
feat: 소유주가 등록한 특정 타이어를 조회하는 기능 작성

### DIFF
--- a/src/properties/properties.controller.ts
+++ b/src/properties/properties.controller.ts
@@ -3,6 +3,7 @@ import {
   Controller,
   Get,
   HttpException,
+  Param,
   Post,
   Query,
   Request,
@@ -20,16 +21,32 @@ export class PropertiesController {
 
   @UseGuards(JwtAuthGuard)
   @Get()
-  async getTireFromUser(
+  async getProperties(
     @Request() req,
     @Query() query: GetPropertiesInput,
   ): Promise<{ count: number; data: Property[] }> {
     const limit = query?.limit ? Number(query.limit) : 5;
-    return await this.propertiesService.getTireFromUser({
+    return await this.propertiesService.getProperties({
       page: Number(query.page),
       limit,
       user: req.user,
     });
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Get('/:id')
+  async getProperty(
+    @Request() req,
+    @Param('id') id: string,
+  ): Promise<Property> {
+    const result = await this.propertiesService.getProperty({
+      id: Number(id),
+      user: req.user,
+    });
+    if (result.ok) {
+      return result.data;
+    }
+    throw new HttpException(result.error, result.httpStatus);
   }
 
   @Post()

--- a/src/properties/properties.service.ts
+++ b/src/properties/properties.service.ts
@@ -23,7 +23,7 @@ export class PropertiesService {
     private connection: Connection,
   ) {}
 
-  async getTireFromUser({
+  async getProperties({
     page,
     limit,
     user,
@@ -41,6 +41,29 @@ export class PropertiesService {
       count: result[1],
       data: result[0],
     };
+  }
+
+  async getProperty({
+    id,
+    user,
+  }: {
+    id: number;
+    user: User;
+  }): Promise<IOutputWithData<Property>> {
+    try {
+      const result = await this.properties.findOne({ idx: id, user });
+      if (result) {
+        return { ok: true, data: result };
+      }
+      return { ok: false, httpStatus: 400, error: '일치하는 정보가 없습니다.' };
+    } catch (error) {
+      console.log(error);
+      return {
+        ok: false,
+        httpStatus: 500,
+        error: '조회 과정에서 에러가 발생했습니다.',
+      };
+    }
   }
 
   private async checkAndReturnUser(id: string): Promise<IOutputWithData<User>> {


### PR DESCRIPTION
## 종류

- [ ] 버그 수정
- [x] 신규 기능 추가
- [ ] 리팩터링
- [ ] 테스트
- [ ] 기타

## 개요

특정 타이어의 정보를 조회하는 기능을 작성했습니다.

## 상세한 내용

- property 의 id 를 URI 파라미터로 입력하고, 로그인으로 얻은 jwt 토큰을 Authorization -> Bearer Token 에 입력하셔야 결과를 조회하실 수 있습니다.
- 해당 property 를 등록한 유저일 경우에만 결과를 출력합니다.
- 해당 기능의 메소드 이름을 `getProperty`로 하면서, 이전에 작성한 목록을 출력하는 메소드 `getTireFromUser`의 이름을 `getProperties`로 수정했습니다.

resolves: #8
