### PR TITLE
refactor/코드 리펙토링

### DIFF
--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -3,6 +3,6 @@ import { Injectable } from '@nestjs/common';
 @Injectable()
 export class AppService {
   getHello(): string {
-    return 'Hello World!';
+    return "원티드 프리온보딩 백엔드 코스의 7번째 과제 '카닥 API'의 메인 페이지입니다. 자세한 안내는 https://github.com/chinsanchung/preonboarding_cardoc 레포지토리에서 얻으실 수 있습니다.";
   }
 }

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -8,7 +8,7 @@ export class AuthController {
 
   @UseGuards(LocalAuthGuard)
   @Post('/login')
-  async login(@Request() req) {
+  login(@Request() req): { access_token: string } {
     return this.authService.login(req.user);
   }
 }

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -2,15 +2,16 @@ import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
-import { UsersModule } from '../users/users.module';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { User } from '../entities/user.entity';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
-import { JwtStrategy } from './strategy/jwt.strategy';
-import { LocalStrategy } from './strategy/local.strategy';
+import { JwtStrategy } from './strategies/jwt.strategy';
+import { LocalStrategy } from './strategies/local.strategy';
 
 @Module({
   imports: [
-    UsersModule,
+    TypeOrmModule.forFeature([User]),
     PassportModule,
     JwtModule.registerAsync({
       imports: [ConfigModule],

--- a/src/auth/dto/auth-user.dto.ts
+++ b/src/auth/dto/auth-user.dto.ts
@@ -1,0 +1,4 @@
+import { PickType } from '@nestjs/mapped-types';
+import { User } from '../../entities/user.entity';
+
+export class AuthUserDto extends PickType(User, ['idx', 'id']) {}

--- a/src/auth/strategies/jwt.strategy.ts
+++ b/src/auth/strategies/jwt.strategy.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
+import { AuthUserDto } from '../dto/auth-user.dto';
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
@@ -13,7 +14,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     });
   }
 
-  async validate(payload: { idx: number; id: string }) {
+  async validate(payload: AuthUserDto): Promise<AuthUserDto> {
     return payload;
   }
 }

--- a/src/auth/strategies/local.strategy.ts
+++ b/src/auth/strategies/local.strategy.ts
@@ -2,6 +2,7 @@ import { HttpException, Injectable } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { Strategy } from 'passport-local';
 import { AuthService } from '../auth.service';
+import { AuthUserDto } from '../dto/auth-user.dto';
 
 @Injectable()
 export class LocalStrategy extends PassportStrategy(Strategy) {
@@ -9,7 +10,7 @@ export class LocalStrategy extends PassportStrategy(Strategy) {
     super({ usernameField: 'id' });
   }
 
-  async validate(id: string, password: string) {
+  async validate(id: string, password: string): Promise<AuthUserDto> {
     const { ok, data, httpStatus, error } = await this.authService.validateUser(
       id,
       password,

--- a/src/properties/dto/tire-info.dto.ts
+++ b/src/properties/dto/tire-info.dto.ts
@@ -1,0 +1,8 @@
+import { PickType } from '@nestjs/mapped-types';
+import { Tire } from '../../entities/tire.entity';
+
+export class TireInfoDto extends PickType(Tire, [
+  'width',
+  'aspect_ratio',
+  'wheel_size',
+]) {}

--- a/src/properties/properties.controller.ts
+++ b/src/properties/properties.controller.ts
@@ -52,7 +52,7 @@ export class PropertiesController {
   @Post()
   async createProperties(
     @Body() createPropertiesInput: CreatePropertiesDto[],
-  ): Promise<any> {
+  ): Promise<string> {
     const inputLength = createPropertiesInput.length;
     if (inputLength == 0 || inputLength > 5) {
       throw new HttpException('1개부터 5개끼지 등록하실 수 있습니다.', 400);
@@ -61,7 +61,7 @@ export class PropertiesController {
       createPropertiesInput,
     );
     if (result.ok) {
-      return '입력해주신 타이어 정보를 저장했습니다. 이전에 같은 아이디와 타이어를 등록한 경우, 중복이라 간주하여 새로 저장하지 않습니다';
+      return '입력해주신 타이어 정보를 저장했습니다. 만일 동일한 아이디와 타이어로 등록했던 항목이 있을 경우, 중복이라 간주하여 새로 저장하지 않습니다';
     }
     throw new HttpException(result.error, result.httpStatus);
   }

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -8,6 +8,5 @@ import { UsersService } from './users.service';
   imports: [TypeOrmModule.forFeature([User])],
   controllers: [UsersController],
   providers: [UsersService],
-  exports: [UsersService],
 })
 export class UsersModule {}

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -27,16 +27,11 @@ export class UsersService {
       await this.users.save(this.users.create({ id, password }));
       return { ok: true };
     } catch (e) {
-      console.log('ERR:', e);
       return {
         ok: false,
         httpStatus: 500,
         error: '유저 생성에 에러가 발생했습니다.',
       };
     }
-  }
-
-  async findOne(id: string): Promise<User | undefined> {
-    return this.users.findOne({ id });
   }
 }


### PR DESCRIPTION
## 종류

- [ ] 버그 수정
- [ ] 신규 기능 추가
- [x] 리팩토링
- [ ] 테스트
- [x] 기타

## 개요

app, auth, properties, users API 에 대한 코드 리펙토링을 수행했습니다.

## 상세한 내용

- 첫 화면의 문자열을 출력하는 app.service.ts 의 getHello 메소드에서 리턴할 내용을 프로젝트에 대해 간단히 언급하는 방식으로 수정했습니다.
- src/auth
    - strategy 폴더의 이름을 다른 폴더의 이름처럼 복수형 명사인 strategies 로 수정했습니다.
    - 유저의 정보를 직접 만든 usersService 의 findOne 메소드로 불러오는 대신, repository 를 선언해서 직접 사용하는 방식으로 수정했습니다. 굳이 usersService 에서 findOne 메소드를 만들어서 가져오는 것보다 이렇게 하는 것이 번거로움을 줄이는 한편 불필요한 코드를 줄일 수 있다고 판단했습니다.
    - 메소드의 리턴 타입을 명시하고, 동일하게 반복하는 user에 대한 타입 선언을 auth-user.dto.ts 라는 파일에 작성해 코드의 중복을 줄였습니다. 그에 따라 auth.module.ts 의 imports 에 적을 내용도 UsersModule 대신 Users 엔티티를 TypeOrmModule 으로 가져오는 방식으로 수정했습니다. 
- src/users
    - auth.service.ts 에서 findOne 메소드를 사용하지 않게 되면서 이 메소드를 삭제했습니다.
- src/properties
    - 컨트롤러의 createProperties 메소드의 리턴 타입을 작성하고, 리턴할 문장을 수정했습니다.
    - service 에서 사용하는 타이어의 타입 선언(width, aspect_ratio, wheel_size)을 tire-info.dto.ts 에 작성해서 코드의 중복을 줄였습니다.
    -  service 의 메소드들의 이름을 더 명확하게 이해할 수 있도록 수정하고, 타이어 엔티티를 리턴하는 checkOrCreateAneReturnTireEntity 메소드의 리턴 타입을 IOutputWithData 로 변경해서 유저 부문과 동일하게 에러 처리를 진행하도록 수정했습니다.

resolves: #1, #6, #7
